### PR TITLE
Edit todo

### DIFF
--- a/src/components/EditTodoForm.js
+++ b/src/components/EditTodoForm.js
@@ -1,0 +1,58 @@
+import React from 'react';
+import { Button, TextField } from '@material-ui/core';
+import { Check } from '@material-ui/icons';
+import useInputState from '../hooks/useInputState';
+import { makeStyles } from '@material-ui/styles';
+
+const useStyles = makeStyles((theme) => ({
+  form: {
+    width: '100%',
+    display: 'flex',
+    alignItems: 'center',
+  },
+  input: {
+    flexGrow: '1',
+    marginRight: '0.5rem',
+  },
+  submit: {
+    height: '40px',
+    minWidth: 'unset',
+    padding: '6px 12px',
+    '& > span > span': {
+      margin: 0,
+    },
+  },
+}));
+
+function EditTodoForm({ todo, editTodo, toggleIsEditing }) {
+  const [value, handleChange, reset] = useInputState(todo.task);
+  const handleSubmit = e => {
+    e.preventDefault();
+    editTodo(todo.id, value);
+    reset();
+    toggleIsEditing();
+  };
+  const classes = useStyles();
+  return (
+    <form className={classes.form} onSubmit={handleSubmit}>
+      <TextField
+        value={value}
+        onChange={handleChange}
+        label='Edit your task'
+        variant='outlined'
+        margin='none'
+        size='small'
+        className={classes.input}
+      />
+      <Button
+        type="submit"
+        variant="contained"
+        disableElevation={true}
+        startIcon={<Check size="large" variant="text" />}
+        className={classes.submit}
+      ></Button>
+    </form>
+  )
+}
+
+export default EditTodoForm;

--- a/src/components/EditTodoForm.js
+++ b/src/components/EditTodoForm.js
@@ -42,6 +42,7 @@ function EditTodoForm({ todo, editTodo, toggleIsEditing }) {
         variant='outlined'
         margin='none'
         size='small'
+        autoFocus
         className={classes.input}
       />
       <Button

--- a/src/components/TodoApp.js
+++ b/src/components/TodoApp.js
@@ -25,11 +25,19 @@ function TodoApp() {
     const filteredTodos = todos.filter(todo => todo.id !== todoId);
     setTodos(filteredTodos);
   };
+  const editTodo = todoId => {
+    console.log("EDIT");
+  };
   return (
     <Paper elevation={0}>
       <Grid container justifyContent='center'>
         <Grid item xs={11} md={8} lg={4}>
-          <TodoList todos={todos} toggleTodo={toggleTodo} deleteTodo={deleteTodo} />
+          <TodoList
+            todos={todos}
+            toggleTodo={toggleTodo}
+            deleteTodo={deleteTodo}
+            editTodo={editTodo}
+          />
           <TodoForm addTodo={addTodo} />
         </Grid>
       </Grid>

--- a/src/components/TodoApp.js
+++ b/src/components/TodoApp.js
@@ -25,8 +25,11 @@ function TodoApp() {
     const filteredTodos = todos.filter(todo => todo.id !== todoId);
     setTodos(filteredTodos);
   };
-  const editTodo = todoId => {
-    console.log("EDIT");
+  const editTodo = (todoId, newTask) => {
+    const updatedTodos = todos.map(todo =>
+      todo.id === todoId ? {...todo, task: newTask} : todo
+    );
+    setTodos(updatedTodos);
   };
   return (
     <Paper elevation={0}>

--- a/src/components/TodoApp.js
+++ b/src/components/TodoApp.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { Grid, Paper } from '@material-ui/core';
 import TodoList from './TodoList';
 import useTodoState from '../hooks/useTodoState';

--- a/src/components/TodoApp.js
+++ b/src/components/TodoApp.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { Grid, Paper } from '@material-ui/core';
 import TodoList from './TodoList';
+import useTodoState from '../hooks/useTodoState';
 
 function TodoApp() {
   const initialTodos = [
@@ -8,31 +9,7 @@ function TodoApp() {
     { id: 2, task: 'Meditate', completed: true },
     { id: 3, task: 'Build first project', completed: false }
   ]
-  const [todos, setTodos] = useState(initialTodos);
-  const addTodo = newTask => {
-    if (newTask === "") {
-      return;
-    }
-    const newId = todos.length ? todos[todos.length - 1].id + 1 : 1;
-    const newTodo = { id: newId, task: newTask, completed: false };
-    setTodos([...todos, newTodo]);
-  };
-  const toggleTodo = todoId => {
-    const updatedTodos = todos.map(todo =>
-      todo.id === todoId ? {...todo, completed: !todo.completed} : todo
-    );
-    setTodos(updatedTodos);
-  };
-  const deleteTodo = todoId => {
-    const filteredTodos = todos.filter(todo => todo.id !== todoId);
-    setTodos(filteredTodos);
-  };
-  const editTodo = (todoId, newTask) => {
-    const updatedTodos = todos.map(todo =>
-      todo.id === todoId ? {...todo, task: newTask} : todo
-    );
-    setTodos(updatedTodos);
-  };
+  const {todos, addTodo, toggleTodo, deleteTodo, editTodo} = useTodoState(initialTodos);
   return (
     <Paper elevation={0}>
       <Grid container justifyContent='center'>

--- a/src/components/TodoApp.js
+++ b/src/components/TodoApp.js
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
-import TodoList from './TodoList';
-import TodoForm from './TodoForm';
 import { Grid, Paper } from '@material-ui/core';
+import TodoList from './TodoList';
 
 function TodoApp() {
   const initialTodos = [
@@ -11,6 +10,9 @@ function TodoApp() {
   ]
   const [todos, setTodos] = useState(initialTodos);
   const addTodo = newTask => {
+    if (newTask === "") {
+      return;
+    }
     const newId = todos.length ? todos[todos.length - 1].id + 1 : 1;
     const newTodo = { id: newId, task: newTask, completed: false };
     setTodos([...todos, newTodo]);
@@ -37,11 +39,11 @@ function TodoApp() {
         <Grid item xs={11} md={8} lg={4}>
           <TodoList
             todos={todos}
+            addTodo={addTodo}
             toggleTodo={toggleTodo}
             deleteTodo={deleteTodo}
             editTodo={editTodo}
           />
-          <TodoForm addTodo={addTodo} />
         </Grid>
       </Grid>
     </Paper>

--- a/src/components/TodoForm.js
+++ b/src/components/TodoForm.js
@@ -22,7 +22,7 @@ function TodoForm({ addTodo, toggleIsAdding }) {
   }
   const classes = useStyles();
   return (
-    <Paper elevation={2} className={classes.container} style={{transition: '1.5s ease-in-out'}}>
+    <Paper elevation={2} className={classes.container}>
       <Box display='flex' justifyContent='center' onClick={() => toggleIsAdding()}>
         <IconButton aria-label="close">
           <ExpandMore />

--- a/src/components/TodoForm.js
+++ b/src/components/TodoForm.js
@@ -36,6 +36,7 @@ function TodoForm({ addTodo, toggleIsAdding }) {
           label='What do you want to focus on?'
           variant='outlined'
           margin='normal'
+          autoFocus
           fullWidth />
         <Button variant="contained" fullWidth type="submit">
           Save

--- a/src/components/TodoForm.js
+++ b/src/components/TodoForm.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Box, Button, Divider, Paper, TextField, Typography } from '@material-ui/core';
+import { Box, Button, IconButton, Paper, TextField, Typography } from '@material-ui/core';
+import { ExpandMore } from '@material-ui/icons';
 import { makeStyles } from '@material-ui/styles';
 import useInputState from '../hooks/useInputState';
 
@@ -7,28 +8,27 @@ const useStyles = makeStyles((theme) => ({
   container: {
     padding: '1rem',
   },
-  divider: {
-    width: '70px',
-    height: '4px',
-    borderRadius: '3px',
-    backgroundColor: 'black',
-  }
 }));
 
-function TodoForm({ addTodo }) {
+function TodoForm({ addTodo, toggleIsAdding }) {
   const [value, handleChange, reset] = useInputState('');
   const handleSubmit = e => {
     e.preventDefault();
     addTodo(value);
     reset();
+    if (value === "") {
+      toggleIsAdding()
+    }
   }
   const classes = useStyles();
   return (
-    <Paper className={classes.container}>
-      <Box display='flex' justifyContent='center' marginBottom='1rem'>
-        <Divider flexItem={true} className={classes.divider} />
+    <Paper elevation={2} className={classes.container} style={{transition: '1.5s ease-in-out'}}>
+      <Box display='flex' justifyContent='center' onClick={() => toggleIsAdding()}>
+        <IconButton aria-label="close">
+          <ExpandMore />
+        </IconButton>
       </Box>
-      <Typography gutterBottom variant='h5' align='center'>New task</Typography>
+      <Typography gutterBottom variant='h5' align='center'>Add a new task</Typography>
       <form onSubmit={handleSubmit}>
         <TextField
           value={value}
@@ -38,7 +38,7 @@ function TodoForm({ addTodo }) {
           margin='normal'
           fullWidth />
         <Button variant="contained" fullWidth type="submit">
-          Add task
+          Save
         </Button>
       </form>
     </Paper>

--- a/src/components/TodoForm.js
+++ b/src/components/TodoForm.js
@@ -1,6 +1,19 @@
 import React from 'react';
-import useInputState from '../hooks/useInputState';
 import { Box, Button, Divider, Paper, TextField, Typography } from '@material-ui/core';
+import { makeStyles } from '@material-ui/styles';
+import useInputState from '../hooks/useInputState';
+
+const useStyles = makeStyles((theme) => ({
+  container: {
+    padding: '1rem',
+  },
+  divider: {
+    width: '70px',
+    height: '4px',
+    borderRadius: '3px',
+    backgroundColor: 'black',
+  }
+}));
 
 function TodoForm({ addTodo }) {
   const [value, handleChange, reset] = useInputState('');
@@ -9,13 +22,12 @@ function TodoForm({ addTodo }) {
     addTodo(value);
     reset();
   }
+  const classes = useStyles();
   return (
-    <Paper style={{padding: '1rem'}}>
-      <div style={{ width: '100%', marginBottom: '1rem' }}>
-        <Box display='flex' justifyContent='center'>
-          <Divider flexItem={true} style={{width: '70px', height: '4px', borderRadius: '3px', backgroundColor: 'black'}} />
-        </Box>
-      </div>
+    <Paper className={classes.container}>
+      <Box display='flex' justifyContent='center' marginBottom='1rem'>
+        <Divider flexItem={true} className={classes.divider} />
+      </Box>
       <Typography gutterBottom variant='h5' align='center'>New task</Typography>
       <form onSubmit={handleSubmit}>
         <TextField

--- a/src/components/TodoItem.js
+++ b/src/components/TodoItem.js
@@ -1,27 +1,36 @@
 import React from 'react';
 import { Checkbox, IconButton, ListItem, ListItemIcon, ListItemSecondaryAction, ListItemText } from '@material-ui/core';
 import { Delete, Edit } from '@material-ui/icons';
+import useToggleState from '../hooks/useToggleState';
+import EditTodoForm from './EditTodoForm';
 
 function TodoItem({ todo, toggleTodo, deleteTodo, editTodo }) {
+  const [isEditing, toggleIsEditing] = useToggleState();
   return (
     <ListItem>
-      <ListItemIcon>
-        <Checkbox
-          checked={todo.completed}
-          color="default"
-          aria-label="checkbox"
-          onClick={() => toggleTodo(todo.id)}
-        />
-      </ListItemIcon>
-      <ListItemText>{todo.task}</ListItemText>
-      <ListItemSecondaryAction>
-        <IconButton edge="end" aria-label="delete" onClick={() => deleteTodo(todo.id)}>
-          <Delete />
-        </IconButton>
-        <IconButton edge="end" aria-label="edit" onClick={() => editTodo(todo.id)}>
-          <Edit />
-        </IconButton>
-      </ListItemSecondaryAction>
+      {isEditing ?
+        <EditTodoForm todo={todo} editTodo={editTodo} toggleIsEditing={toggleIsEditing} />
+      :
+        <>
+          <ListItemIcon>
+            <Checkbox
+              checked={todo.completed}
+              color="default"
+              aria-label="checkbox"
+              onClick={() => toggleTodo(todo.id)}
+            />
+          </ListItemIcon>
+          <ListItemText>{todo.task}</ListItemText>
+          <ListItemSecondaryAction>
+            <IconButton edge="end" aria-label="delete" onClick={() => deleteTodo(todo.id)}>
+              <Delete />
+            </IconButton>
+            <IconButton edge="end" aria-label="edit" onClick={() => toggleIsEditing()}>
+              <Edit />
+            </IconButton>
+          </ListItemSecondaryAction>
+        </>
+      }
     </ListItem>
   )
 }

--- a/src/components/TodoItem.js
+++ b/src/components/TodoItem.js
@@ -1,11 +1,19 @@
 import React from 'react';
 import { Checkbox, IconButton, ListItem, ListItemIcon, ListItemSecondaryAction, ListItemText } from '@material-ui/core';
 import { Delete, Edit } from '@material-ui/icons';
+import { makeStyles } from '@material-ui/styles';
 import useToggleState from '../hooks/useToggleState';
 import EditTodoForm from './EditTodoForm';
 
+const useStyles = makeStyles((theme) => ({
+  root: {
+    maxWidth: '70%',
+  },
+}));
+
 function TodoItem({ todo, toggleTodo, deleteTodo, editTodo }) {
   const [isEditing, toggleIsEditing] = useToggleState();
+  const classes = useStyles();
   return (
     <ListItem>
       {isEditing ?
@@ -20,7 +28,7 @@ function TodoItem({ todo, toggleTodo, deleteTodo, editTodo }) {
               onClick={() => toggleTodo(todo.id)}
             />
           </ListItemIcon>
-          <ListItemText>{todo.task}</ListItemText>
+          <ListItemText classes={{root: classes.root}}>{todo.task}</ListItemText>
           <ListItemSecondaryAction>
             <IconButton edge="end" aria-label="delete" onClick={() => deleteTodo(todo.id)}>
               <Delete />

--- a/src/components/TodoItem.js
+++ b/src/components/TodoItem.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import { Checkbox, IconButton, ListItem, ListItemIcon, ListItemSecondaryAction, ListItemText } from '@material-ui/core';
-import { Delete } from '@material-ui/icons';
+import { Delete, Edit } from '@material-ui/icons';
 
-function TodoItem({ todo, toggleTodo, deleteTodo }) {
+function TodoItem({ todo, toggleTodo, deleteTodo, editTodo }) {
   return (
     <ListItem>
       <ListItemIcon>
@@ -17,6 +17,9 @@ function TodoItem({ todo, toggleTodo, deleteTodo }) {
       <ListItemSecondaryAction>
         <IconButton edge="end" aria-label="delete" onClick={() => deleteTodo(todo.id)}>
           <Delete />
+        </IconButton>
+        <IconButton edge="end" aria-label="edit" onClick={() => editTodo(todo.id)}>
+          <Edit />
         </IconButton>
       </ListItemSecondaryAction>
     </ListItem>

--- a/src/components/TodoList.js
+++ b/src/components/TodoList.js
@@ -2,7 +2,7 @@ import React from 'react';
 import TodoItem from './TodoItem';
 import { List, Paper, Typography } from '@material-ui/core';
 
-function TodoList({ todos, toggleTodo, deleteTodo }) {
+function TodoList({ todos, toggleTodo, deleteTodo, editTodo }) {
   return (
     <Paper>
       <Typography gutterBottom variant='h3' align='center'>
@@ -10,7 +10,13 @@ function TodoList({ todos, toggleTodo, deleteTodo }) {
       </Typography>
       <List>
         {todos.map(todo => (
-          <TodoItem key={todo.id} todo={todo} toggleTodo={toggleTodo} deleteTodo={deleteTodo} />
+          <TodoItem
+            key={todo.id}
+            todo={todo}
+            toggleTodo={toggleTodo}
+            deleteTodo={deleteTodo}
+            editTodo={editTodo}
+          />
         ))}
       </List>
     </Paper>

--- a/src/components/TodoList.js
+++ b/src/components/TodoList.js
@@ -1,14 +1,44 @@
 import React from 'react';
+import { Button, Grid, List, Paper, Typography } from '@material-ui/core';
+import { makeStyles } from '@material-ui/styles';
 import TodoItem from './TodoItem';
-import { List, Paper, Typography } from '@material-ui/core';
+import TodoForm from './TodoForm';
+import useToggleState from '../hooks/useToggleState';
+import { ExpandLess } from '@material-ui/icons';
 
-function TodoList({ todos, toggleTodo, deleteTodo, editTodo }) {
+const useStyles = makeStyles((theme) => ({
+  container: {
+    height: '100vh',
+  },
+  list: {
+    height: '100%',
+  },
+  formContainer: {
+    position: 'fixed',
+    bottom: '0',
+    left: '0',
+    width: '100%',
+    backgroundColor: 'transparent',
+  },
+  buttonContainer: {
+    padding: '1rem',
+  },
+}));
+
+function TodoList({ todos, addTodo, toggleTodo, deleteTodo, editTodo }) {
+  const [isAdding, toggleIsAdding] = useToggleState(false);
+  const closeTodoForm = () => {
+    if (isAdding) {
+      toggleIsAdding()
+    }
+  };
+  const classes = useStyles();
   return (
-    <Paper>
+    <Paper className={classes.container}>
       <Typography gutterBottom variant='h3' align='center'>
         All Tasks
       </Typography>
-      <List>
+      <List onClick={closeTodoForm} className={classes.list}>
         {todos.map(todo => (
           <TodoItem
             key={todo.id}
@@ -19,6 +49,21 @@ function TodoList({ todos, toggleTodo, deleteTodo, editTodo }) {
           />
         ))}
       </List>
+      <Paper className={classes.formContainer} elevation={0} >
+        <Grid container justifyContent='center'>
+          <Grid item xs={11} md={8} lg={4}>
+            { isAdding ?
+              <TodoForm addTodo={addTodo} toggleIsAdding={toggleIsAdding} />
+              :
+              <div className={classes.buttonContainer}>
+                <Button variant="contained" startIcon={<ExpandLess />} fullWidth onClick={() => toggleIsAdding()}>
+                  Add a new task
+                </Button>
+              </div>
+            }
+          </Grid>
+        </Grid>
+      </Paper>
     </Paper>
   )
 }

--- a/src/components/TodoList.js
+++ b/src/components/TodoList.js
@@ -59,13 +59,18 @@ function TodoList({ todos, addTodo, toggleTodo, deleteTodo, editTodo }) {
 
     toggleIsAdding();
   };
+  const closeDrawer = () => {
+    if (isAdding) {
+      toggleIsAdding();
+    }
+  }
   const classes = useStyles();
   return (
     <Paper className={classes.container}>
       <Typography gutterBottom variant='h3' align='center'>
         All Tasks
       </Typography>
-      <List id="task-list" className={clsx(classes.list, {[classes.collapse]: isAdding})}>
+      <List id="task-list" className={clsx(classes.list, {[classes.collapse]: isAdding})} onClick={() => closeDrawer()}>
         {todos.map(todo => (
           <TodoItem
             key={todo.id}

--- a/src/hooks/useTodoState.js
+++ b/src/hooks/useTodoState.js
@@ -1,0 +1,39 @@
+import { useState } from 'react';
+
+const useTodoState = initialTodos => {
+  const [todos, setTodos] = useState(initialTodos);
+  const addTodo = newTask => {
+    if (newTask === "") {
+      return;
+    }
+    const newId = todos.length ? todos[todos.length - 1].id + 1 : 1;
+    const newTodo = { id: newId, task: newTask, completed: false };
+    setTodos([...todos, newTodo]);
+  };
+  const toggleTodo = todoId => {
+    const updatedTodos = todos.map(todo =>
+      todo.id === todoId ? {...todo, completed: !todo.completed} : todo
+    );
+    setTodos(updatedTodos);
+  };
+  const deleteTodo = todoId => {
+    const filteredTodos = todos.filter(todo => todo.id !== todoId);
+    setTodos(filteredTodos);
+  };
+  const editTodo = (todoId, newTask) => {
+    const updatedTodos = todos.map(todo =>
+      todo.id === todoId ? {...todo, task: newTask} : todo
+    );
+    setTodos(updatedTodos);
+  };
+
+  return {
+    todos,
+    addTodo,
+    toggleTodo,
+    deleteTodo,
+    editTodo
+  }
+};
+
+export default useTodoState;

--- a/src/hooks/useToggleState.js
+++ b/src/hooks/useToggleState.js
@@ -1,0 +1,11 @@
+import { useState } from 'react';
+
+const useToggleState = (initialValue = false) => {
+  const [state, setState] = useState(initialValue);
+  const toggle = () => {
+    setState(!state);
+  };
+  return [state, toggle];
+};
+
+export default useToggleState;

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,9 @@ import reportWebVitals from './reportWebVitals';
 
 ReactDOM.render(
   <React.StrictMode>
+  {/* <React.Fragment> */}
     <App />
+  {/* </React.Fragment>, */}
   </React.StrictMode>,
   document.getElementById('root')
 );


### PR DESCRIPTION
I created an `editTodoForm` component and reused the custom hook `useInputState` to edit a todo and added the styling.
Then I moved the form to add a new task into a `Drawer` Material UI component to make it slide in from the bottom when the user clicks on a button. To toggle the form I create another custom hook `useToggleState`.
Finally I moved the actions the user can perform on the tasks into a separate custom hook `useTodoState` and added style to the list of todos.
I also refactored all the code for the style using `makeStyles` from Material UI.

_Note: I chose to keep the following warning for now_
> Warning: findDOMNode is deprecated in StrictMode. findDOMNode was passed an instance of Transition which is inside StrictMode. Instead, add a ref directly to the element you want to reference. Learn more about using refs safely here: https://reactjs.org/link/strict-mode-find-node

_It could be removed by replacing `React.StrictMode` with `React.Fragment` in **index.js** or by adding a ref or by waiting for the next upgrade._