### PR TITLE
Edit todo api

### DIFF
--- a/src/components/EditTodoForm.js
+++ b/src/components/EditTodoForm.js
@@ -25,10 +25,10 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 function EditTodoForm({ todo, editTodo, toggleIsEditing }) {
-  const [value, handleChange, reset] = useInputState(todo.task);
+  const [value, handleChange, reset] = useInputState(todo.name);
   const handleSubmit = e => {
     e.preventDefault();
-    editTodo(todo.id, value);
+    editTodo(todo.id, value, todo.completed);
     reset();
     toggleIsEditing();
   };

--- a/src/components/TodoItem.js
+++ b/src/components/TodoItem.js
@@ -11,7 +11,7 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-function TodoItem({ todo, toggleTodo, deleteTodo, editTodo }) {
+function TodoItem({ todo, deleteTodo, editTodo }) {
   const [isEditing, toggleIsEditing] = useToggleState();
   const classes = useStyles();
   return (
@@ -25,7 +25,7 @@ function TodoItem({ todo, toggleTodo, deleteTodo, editTodo }) {
               checked={todo.completed}
               color="default"
               aria-label="checkbox"
-              onClick={() => toggleTodo(todo.id)}
+              onClick={() => editTodo(todo.id, todo.name, !todo.completed)}
             />
           </ListItemIcon>
           <ListItemText classes={{root: classes.root}}>{todo.name}</ListItemText>

--- a/src/components/TodoList.js
+++ b/src/components/TodoList.js
@@ -16,7 +16,7 @@ const useStyles = makeStyles((theme) => ({
 
 function TodoList() {
   const classes = useStyles();
-  const {todos, setTodos, addTodo, toggleTodo, deleteTodo, editTodo} = useTodoState([]);
+  const {todos, setTodos, addTodo, deleteTodo, editTodo} = useTodoState([]);
   useEffect(() => {
     const taskList = document.getElementById('task-list');
     if (taskList.children.length > 0) {
@@ -39,7 +39,6 @@ function TodoList() {
           <TodoItem
             key={todo.id}
             todo={todo}
-            toggleTodo={toggleTodo}
             deleteTodo={deleteTodo}
             editTodo={editTodo}
           />

--- a/src/hooks/useTodoState.js
+++ b/src/hooks/useTodoState.js
@@ -13,12 +13,6 @@ const useTodoState = initialTodos => {
     }
     createTodo(newTask);
   };
-  const toggleTodo = todoId => {
-    const updatedTodos = todos.map(todo =>
-      todo.id === todoId ? {...todo, completed: !todo.completed} : todo
-    );
-    setTodos(updatedTodos);
-  };
   const deleteTodo = todoId => {
     async function destroyTodo(id) {
       const response = await axios.delete(`https://rails-timed-task-tracker-api.herokuapp.com/api/v1/tasks/${id}`)
@@ -26,18 +20,18 @@ const useTodoState = initialTodos => {
       }
     destroyTodo(todoId);
   };
-  const editTodo = (todoId, newTask) => {
-    const updatedTodos = todos.map(todo =>
-      todo.id === todoId ? {...todo, task: newTask} : todo
-    );
-    setTodos(updatedTodos);
-  };
+  const editTodo = (todoId, editedName, editedCompleted) => {
+		async function updateTodo(id, name, completed) {
+      const response = await axios.put(`https://rails-timed-task-tracker-api.herokuapp.com/api/v1/tasks/${id}`,{ name: name, completed: completed });
+      setTodos(response.data);
+    }
+		updateTodo(todoId, editedName, editedCompleted);
+	}
 
   return {
     todos,
     setTodos,
     addTodo,
-    toggleTodo,
     deleteTodo,
     editTodo
   }

--- a/src/hooks/useTodoState.js
+++ b/src/hooks/useTodoState.js
@@ -19,7 +19,7 @@ const useTodoState = initialTodos => {
     async function destroyTodo(id) {
       const response = await axios.delete(`${baseUrl}/${id}`)
       setTodos(response.data);
-      }
+    }
     destroyTodo(todoId);
   };
   const editTodo = (todoId, editedName, editedCompleted) => {

--- a/src/hooks/useTodoState.js
+++ b/src/hooks/useTodoState.js
@@ -1,6 +1,8 @@
 import { useState } from 'react';
 import axios from 'axios';
 
+const baseUrl = 'https://rails-timed-task-tracker-api.herokuapp.com/api/v1/tasks';
+
 const useTodoState = initialTodos => {
   const [todos, setTodos] = useState(initialTodos);
   const addTodo = newTask => {
@@ -8,21 +10,21 @@ const useTodoState = initialTodos => {
       return;
     }
     async function createTodo(newTask) {
-      const response = await axios.post('https://rails-timed-task-tracker-api.herokuapp.com/api/v1/tasks', { name: newTask });
+      const response = await axios.post(baseUrl, { name: newTask });
       setTodos([...todos, response.data]);
     }
     createTodo(newTask);
   };
   const deleteTodo = todoId => {
     async function destroyTodo(id) {
-      const response = await axios.delete(`https://rails-timed-task-tracker-api.herokuapp.com/api/v1/tasks/${id}`)
+      const response = await axios.delete(`${baseUrl}/${id}`)
       setTodos(response.data);
       }
     destroyTodo(todoId);
   };
   const editTodo = (todoId, editedName, editedCompleted) => {
 		async function updateTodo(id, name, completed) {
-      const response = await axios.put(`https://rails-timed-task-tracker-api.herokuapp.com/api/v1/tasks/${id}`,{ name: name, completed: completed });
+      const response = await axios.put(`${baseUrl}/${id}`,{ name: name, completed: completed });
       setTodos(response.data);
     }
 		updateTodo(todoId, editedName, editedCompleted);


### PR DESCRIPTION
Originally editing a todo was done under 2 different actions. One was editing the name and the other was un/checking a todo as completed.
In the **useTodoState** file there were 2 different functions, `toggleTodo` and `editTodo`.  The API having only one request to update a todo I kept `editTodo` to grouped the 2 functions. Now this function has 3 arguments and I modified how it's called in the necessary places.